### PR TITLE
Implement prefix handling and prefix -commmand

### DIFF
--- a/cmdHandler/cmdHandler.js
+++ b/cmdHandler/cmdHandler.js
@@ -4,15 +4,15 @@ const argParser = require('./argParser.js');
 const cmdLoader = require('./cmdLoader.js');
 
 class commandHandler {
-    constructor(client, statTracker) {
+    constructor(client, cmdPass) {
         this.client = client;
-        this.statTracker = statTracker;
+        this.statTracker = cmdPass.statTracker;
 
         this.commands = { };
         this.helpTexts = { };
         this.executedCmds = new Map();
 
-        this.loadCommands();
+        this.loadCommands(cmdPass);
     }
 
     /*
@@ -65,9 +65,9 @@ class commandHandler {
     /*
         LOADING
     */
-    async loadCommands() {
+    async loadCommands(cmdPass) {
         return new Promise(async resolve => {
-            let ret = await cmdLoader.load(this.statTracker);
+            let ret = await cmdLoader.load(cmdPass);
             
             this.commands = ret.commands;
             this.helpTexts = ret.helpTexts;

--- a/cmdHandler/cmdLoader.js
+++ b/cmdHandler/cmdLoader.js
@@ -5,7 +5,7 @@ const async = require('async');
 
 class Loader {
     /* Loads commands and builds the commands and help object */
-    static load(statTracker) {
+    static load(cmdPass) {
         return new Promise(async resolve => {
             // Full commands, returnable lists
             let moduleHelpTexts = {};
@@ -30,7 +30,7 @@ class Loader {
                         let commandObj = require(path.join(process.cwd(), 'modules', modulePath, cmdPath));
 
                         // Pass stat tracker to commands
-                        let command = new commandObj(statTracker);
+                        let command = new commandObj(cmdPass);
 
                         /* Insert data */
                         if (command.helpText != null) {

--- a/index.js
+++ b/index.js
@@ -25,9 +25,18 @@ try {
 let statTracker = require('./utils/statTracker.js');
 statTracker = new statTracker();
 
+// Initialize prefixHandler
+let prefixHandler = require('./msgHandler/prefixHandler.js');
+prefixHandler = new prefixHandler();
+
+const cmdPass = {
+    prefixHandler,
+    statTracker
+}
+
 // Initialize message handler
 let msgHandler = require('./msgHandler/msgHandler.js');
-msgHandler = new msgHandler(client, statTracker);
+msgHandler = new msgHandler(client, statTracker, cmdPass);
 
 // Database migration
 dbUtil.migrate();

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const cmdPass = {
 
 // Initialize message handler
 let msgHandler = require('./msgHandler/msgHandler.js');
-msgHandler = new msgHandler(client, statTracker, cmdPass);
+msgHandler = new msgHandler(client, cmdPass);
 
 // Database migration
 dbUtil.migrate();

--- a/migrations/20180228174019_prefix2.js
+++ b/migrations/20180228174019_prefix2.js
@@ -1,9 +1,10 @@
 
-exports.up = function(knex, Promise) {
+exports.up = async function(knex, Promise) {
+    await knex.schema.dropTable('prefixes');
     return Promise.all([
         knex.schema.createTable('prefixes', table => {
-            table.string('guildid').notNullable(),
-            table.string('prefix').notNullable()
+            table.string('guild').primary(),
+            table.string('prefix')
         })
     ]);
 };

--- a/modules/Admin/prefix.js
+++ b/modules/Admin/prefix.js
@@ -1,6 +1,38 @@
 const Command = require('../../Types/command.js');
 
 class Prefix extends Command {
+    constructor(cmdPass) {
+        super({
+            args: 2,
+            ignoreMin: true,
+            userPerms: ['MANAGE_GUILD']
+        });
 
+        this.prefixHandler = cmdPass.prefixHandler;
+    }
+
+    async run(bot, msg, args) {
+        if (args == null)
+            throw 'Not enough arguments!';
+
+        switch(args[0]) {
+            case 'set':
+                // Don't allow for null input, empty input or input with spaces
+                if (args[1] && args[1].trim() != '' && !args[1].includes(' ')) {
+                    await this.prefixHandler.set(msg.guild.id, args[1]);
+                    await super.sendBasicSuccess(msg, 'Prefix changed!');
+                }
+                else
+                    throw 'Invalid prefix!'
+                break;
+            case 'clear':
+                // prefixHandler set null sets to default prefix
+                await this.prefixHandler.set(msg.guild.id, null);
+                await super.sendBasicSuccess(msg, 'Prefix set back to default!');
+                break;
+            default:
+                throw 'Unknown submenu';
+        }
+    }
 }
 module.exports = Prefix;

--- a/modules/Admin/prefix.js
+++ b/modules/Admin/prefix.js
@@ -1,0 +1,6 @@
+const Command = require('../../Types/command.js');
+
+class Prefix extends Command {
+
+}
+module.exports = Prefix;

--- a/modules/Utility/stats.js
+++ b/modules/Utility/stats.js
@@ -2,10 +2,10 @@ const Discord = require('discord.js');
 const Command = require('../../Types/command.js');
 
 class Stats extends Command {
-    constructor(statTracker) {
+    constructor(cmdPass) {
         super();
 
-        this.statTracker = statTracker;
+        this.statTracker = cmdPass.statTracker;
 
         this.cpuStartTime = process.hrtime();
         this.cpuStartUsage = process.cpuUsage();

--- a/msgHandler/msgHandler.js
+++ b/msgHandler/msgHandler.js
@@ -33,6 +33,7 @@ class msgHandler {
                 await this.cmdHandler.run(message, cmd, argString);
             } catch (err) {
                 await throwErr(message, err);
+
                 throw err;
             }
         }
@@ -42,12 +43,9 @@ module.exports = msgHandler;
 
 /* Error messaging */
 async function throwErr(message, err) {
-    return new Promise(async resolve => {
-        await message.channel.send(new Discord.RichEmbed()
-        .setColor('YELLOW')
-        .setTitle('Woops!')
-        .setDescription(err)
-        .setFooter('This is an error. You should not be seeing this.'));
-        resolve();
-    });
+    await message.channel.send(new Discord.RichEmbed()
+    .setColor('YELLOW')
+    .setTitle('Woops!')
+    .setDescription(err)
+    .setFooter('This is an error. You should not be seeing this.'));
 }

--- a/msgHandler/msgHandler.js
+++ b/msgHandler/msgHandler.js
@@ -4,7 +4,7 @@ const defaultPrefix = require('../data/config.json').defaultPrefix;
 const cmdHandler = require('../cmdHandler/cmdHandler.js');
 
 class msgHandler {
-    constructor(client, statTracker, cmdPass) {
+    constructor(client, cmdPass) {
         this.client = client;
         this.statTracker = cmdPass.statTracker;
         this.prefixHandler = cmdPass.prefixHandler;

--- a/msgHandler/msgHandler.js
+++ b/msgHandler/msgHandler.js
@@ -2,15 +2,15 @@ const Discord = require('discord.js');
 const db = require('../utils/dbUtil.js');
 const defaultPrefix = require('../data/config.json').defaultPrefix;
 const cmdHandler = require('../cmdHandler/cmdHandler.js');
-const prefixHandler = new (require('./prefixHandler.js'))();
 
 class msgHandler {
-    constructor(client, statTracker) {
+    constructor(client, statTracker, cmdPass) {
         this.client = client;
-        this.statTracker = statTracker;
+        this.statTracker = cmdPass.statTracker;
+        this.prefixHandler = cmdPass.prefixHandler;
 
         // Initialize command handler
-        this.cmdHandler = new cmdHandler(client, statTracker);
+        this.cmdHandler = new cmdHandler(client, cmdPass);
     }
 
     async onMessageEvent(message) {
@@ -22,13 +22,11 @@ class msgHandler {
         this.statTracker.messageAdd();
 
         // Get guild's command prefix
-        const test = (message.guild) ? true : false;
-        const prefix = (message.guild) ? await prefixHandler.get(message.guild.id) : defaultPrefix;
+        const prefix = (message.guild) ? await this.prefixHandler.get(message.guild.id) : defaultPrefix;
+
         if (message.content.startsWith(prefix)) {
-            /*
-                Split the command and arguments from eachother
-            */
-            const cmd = (message.content.indexOf(' ') > 0) ? message.content.substring(prefix.length, message.content.indexOf(' ') - (prefix.length - 1)) : message.content.substring(prefix.length);
+            // Split the command and arguments from each other testprefix set !
+            const cmd = (message.content.indexOf(' ') > 0) ? message.content.substring(prefix.length, message.content.indexOf(' ')) : message.content.substring(prefix.length);
             const argString = (message.content.indexOf(' ') > 0) ? message.content.substring(message.content.indexOf(' ') + 1) : null;
 
             try {

--- a/msgHandler/prefixHandler.js
+++ b/msgHandler/prefixHandler.js
@@ -31,6 +31,12 @@ class prefixHandler {
     }
 
     async set(id, prefix) {
+        if (prefix == null)
+            prefix = defaultPrefix;
+
+        if (prefix == this.prefixes.get(id))
+            throw 'The server already has this prefix!';
+
         this.prefixes.set(id, prefix);
 
         // If DB already contains information, update it

--- a/msgHandler/prefixHandler.js
+++ b/msgHandler/prefixHandler.js
@@ -1,0 +1,48 @@
+const db = require('../utils/dbUtil.js');
+const defaultPrefix = require('../data/config.json').defaultPrefix;
+
+class prefixHandler {
+    constructor() {
+        this.prefixes = new Map();
+    }
+
+    async get(id) {
+        // If we already have the prefix cached, return it instead of hitting the db
+        if (this.prefixes.has(id))
+            return this.prefixes.get(id);
+        else {
+            // Doesn't exist, get from the database
+            if (await db.ifRowExists('prefixes', { guild: id })) {
+                const rows = await db.getRow('prefixes', { guild: id });
+                const prefix = rows[0].prefix;
+
+
+                // Update cache
+                this.prefixes.set(id, prefix);
+                
+                return prefix;
+            } else {
+                // The db didn't contain a prefix, set cache to default
+                this.prefixes.set(id, defaultPrefix);
+
+                return defaultPrefix;
+            }
+        }
+    }
+
+    async set(id, prefix) {
+        this.prefixes.set(id, prefix);
+
+        // If DB already contains information, update it
+        // Otherwise insert data
+        if (await db.ifRowExists('prefixes', { guild: id })) {
+            await db.updateRow('prefixes', { guild: id }, { prefix : prefix });
+        } else {
+            await db.addData('prefixes', {
+                guild: id,
+                prefix: prefix
+            });
+        }
+    }
+}
+module.exports = prefixHandler;

--- a/prefixCache/index.js
+++ b/prefixCache/index.js
@@ -1,8 +1,0 @@
-/*
-    File exists so cache can be updated from various places.
-    E.g. it should be updated from msgHandler on first command run
-    and from setprefix command.
-*/
-
-let cache = new Map();
-module.exports = cache;


### PR DESCRIPTION
Implements per guild prefix handling and also implements the command for changing the prefix.

Also changes the way how objects are passed to commands. Instead of passing everything one by one to command constructor, it is built to an object in index.js and passed to commands through `cmdLoader.load()`.